### PR TITLE
fix: Fixing Jest failure by removing .js extensions from secret.ts imports

### DIFF
--- a/src/secret.ts
+++ b/src/secret.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from "node:crypto";
-import { Algorithm, Encoding } from "./types/index.js";
-import { base32Decode, base32Encode } from "./encoding/index.js";
+import { Algorithm, Encoding } from "./types";
+import { base32Decode, base32Encode } from "./encoding";
 
 export class Secret {
   #buffer: Buffer;


### PR DESCRIPTION
## Summary
- Fix Jest unit test failure caused by `.js` extensions in `src/secret.ts` imports
- Restore CI `unit` job so `npm test` passes on Node after the cross-runtime smoke merge

## Context
After merging cross-runtime smoke tests, the `unit` CI job failed because Jest could not resolve `./encoding/index.js` and `./types/index.js` from `secret.ts`. Smoke tests passed independently; this change fixes the Jest/source test path only.

## Test plan
- [x] `npm test`
- [x] `npm run build`
- [x] CI `unit` job passes on this PR