### PR TITLE
Add GitHub Actions workflow for npm and GitHub Release publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,52 @@
+name: Publish
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      - name: Read version
+        id: version
+        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - run: npm ci
+      - run: npm test
+      - run: npm run build
+
+      - name: Skip if version already on npm
+        id: check
+        run: |
+          if npm view "xotp@${{ steps.version.outputs.version }}" version 2>/dev/null; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "xotp@${{ steps.version.outputs.version }} already published — skipping"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish to npm
+        if: steps.check.outputs.skip != 'true'
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub Release
+        if: steps.check.outputs.skip != 'true'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.version.outputs.version }}
+          generate_release_notes: true


### PR DESCRIPTION
## Summary
- Add a `Publish` workflow that runs on pushes to `main` and via manual `workflow_dispatch`
- Publishes to npm with provenance when `package.json` version is not already on the registry
- Creates a matching GitHub Release (`v{version}`) with auto-generated release notes

## Release flow
After this merges:
1. Bump `version` in `package.json` in a release PR
2. Merge to `main` after CI passes
3. The publish workflow runs automatically and publishes to npm + GitHub
Merges without a version bump are no-ops (the workflow skips if that version already exists on npm).

## Requirements
- `NPM_TOKEN` must be configured in GitHub Actions secrets (already done)

## Test plan
- [ ] Merge this PR and confirm the Publish workflow runs on `main`
- [ ] Confirm it skips publish for the current version (`1.0.16` is already on npm)
- [ ] On the next release PR, bump version, merge, and verify npm publish + GitHub Release are created
- [ ] Optionally trigger **Actions → Publish → Run workflow** to confirm manual re-run works