### PR TITLE
chore: release 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xotp",
-  "version": "1.0.16",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xotp",
-      "version": "1.0.16",
+      "version": "1.1.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.13",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "xotp",
   "description": "One-Time Password (HOTP/TOTP) library for Node.js, Deno and Bun, with support for Google Authenticator.",
   "author": "Farshid Beheshti",
-  "version": "1.0.16",
+  "version": "1.1.0",
   "type": "commonjs",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
Release the changes already merged to `main` by bumping the package version to `1.1.0`.