### PR TITLE
ci: upload test coverage to Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,14 +9,19 @@ jobs:
   unit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm
       - run: npm ci
       - run: npm run build
-      - run: npm test
+      - run: npm run test:coverage
+      - uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage/lcov.info
+          fail_ci_if_error: false
 
   smoke:
     runs-on: ubuntu-latest
@@ -41,8 +46,8 @@ jobs:
             format: esm
             command: deno run --allow-read tests/smoke/esm.mjs
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm
@@ -61,8 +66,8 @@ jobs:
       matrix:
         format: [cjs, esm]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,9 +13,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 
 [![npm version](https://img.shields.io/npm/v/xotp)](https://www.npmjs.com/package/xotp)
 [![CI](https://github.com/farshidbeheshti/xotp/actions/workflows/ci.yml/badge.svg)](https://github.com/farshidbeheshti/xotp/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/farshidbeheshti/xotp/graph/badge.svg)](https://codecov.io/gh/farshidbeheshti/xotp)
 [![License: MIT](https://img.shields.io/github/license/farshidbeheshti/xotp)](https://github.com/farshidbeheshti/xotp/blob/master/LICENSE)
 [![TypeScript](https://img.shields.io/badge/TypeScript-3178C9?logo=TypeScript&logoColor=white)](https://github.com/farshidbeheshti/xotp)
 [![demo](https://img.shields.io/badge/demo-xotp.dev-026dfd)](https://xotp.dev)

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,4 +9,7 @@ module.exports = {
   },
   moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths),
   modulePaths: ["<rootDir>"],
+  collectCoverageFrom: ["src/**/*.ts"],
+  coverageDirectory: "coverage",
+  coverageReporters: ["text", "lcov"],
 };

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "build": "tsc && node scripts/build-esm-entry.mjs",
     "prepare": "npm run build",
     "clean": "rimraf ./dist",
-    "test:coverage": "rimraf ./coverage & jest --coverage",
+    "test:coverage": "rimraf ./coverage && jest --coverage",
     "test": "jest",
     "test:smoke": "node tests/smoke/cjs.cjs && node tests/smoke/esm.mjs",
     "test:smoke:consumer:cjs": "node scripts/test-smoke-consumer.mjs cjs",


### PR DESCRIPTION
## Summary
- Run `npm run test:coverage` in the CI unit job (replaces `npm test` there; coverage run still executes the full Jest suite)
- Upload `coverage/lcov.info` to Codecov via `codecov/codecov-action@v5`
- Configure Jest to collect coverage from `src/**/*.ts` and emit `lcov` reports
- Fix `test:coverage` script to use `&&` instead of `&`
- Add Codecov badge to the README
- Bump `actions/checkout` and `actions/setup-node` from v4 to v5 in CI and publish workflows

The README badge will populate after the first successful upload on `main`.
