### PR TITLE
test: expand unit coverage and restore CodeCov in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,12 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
-      - run: npm test
+      - run: npm run test:coverage
+      - uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage/lcov.info
+          fail_ci_if_error: false
 
   smoke:
     runs-on: ubuntu-latest

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,4 +9,7 @@ module.exports = {
   },
   moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths),
   modulePaths: ["<rootDir>"],
+  collectCoverageFrom: ["src/**/*.ts"],
+  coverageDirectory: "coverage",
+  coverageReporters: ["text", "lcov"],
 };

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "build": "tsc && node scripts/build-esm-entry.mjs",
     "prepare": "npm run build",
     "clean": "rimraf ./dist",
-    "test:coverage": "rimraf ./coverage & jest --coverage",
+    "test:coverage": "rimraf ./coverage && jest --coverage",
     "test": "jest",
     "test:smoke": "node tests/smoke/cjs.cjs && node tests/smoke/esm.mjs",
     "test:smoke:consumer:cjs": "node scripts/test-smoke-consumer.mjs cjs",

--- a/tests/encoding/uint8.test.ts
+++ b/tests/encoding/uint8.test.ts
@@ -1,0 +1,29 @@
+import {
+  uintDecode,
+  uintEncode,
+  uint64Decode,
+  uint64Encode,
+} from "../../src/encoding/uint8";
+
+describe("uintEncode / uintDecode", () => {
+  test("round-trips a counter value", () => {
+    expect(uintDecode(uintEncode(123456789))).toBe(123456789);
+  });
+
+  test("uintDecode accepts Buffer", () => {
+    const bytes = uintEncode(42);
+    expect(uintDecode(Buffer.from(bytes))).toBe(42);
+  });
+});
+
+describe("uint64Encode / uint64Decode", () => {
+  test("round-trips a bigint value", () => {
+    const value = BigInt(9007199254740992); // 2 ** 53
+    expect(uint64Decode(uint64Encode(value))).toBe(value);
+  });
+
+  test("uint64Decode accepts Buffer", () => {
+    const bytes = uint64Encode(BigInt(99));
+    expect(uint64Decode(Buffer.from(bytes))).toBe(BigInt(99));
+  });
+});

--- a/tests/hotp.test.ts
+++ b/tests/hotp.test.ts
@@ -44,3 +44,30 @@ describe("instance secret", () => {
     expect(hotp.generate({ counter })).toBe(expected);
   });
 });
+
+describe("validate", () => {
+  test("returns true for a matching token and false otherwise", () => {
+    const secretKey = Secret.from(secret, "ascii");
+    const hotp = new HOTP({ secret: secretKey, counter: 0 });
+    const token = hotp.generate({ counter: 0 });
+    expect(hotp.validate({ token, counter: 0 })).toBe(true);
+    expect(hotp.validate({ token: "000000", counter: 0 })).toBe(false);
+  });
+});
+
+describe("compare", () => {
+  test("returns a negative delta when the token matches a past counter", () => {
+    const secretKey = Secret.from(secret, "ascii");
+    const hotp = new HOTP({ window: 2 });
+    const token = hotp.generate({ secret: secretKey, counter: 5 });
+    expect(hotp.compare({ token, secret: secretKey, counter: 7 })).toBe(-2);
+  });
+});
+
+describe("toKeyUri", () => {
+  test("deprecated keyUri delegates to toKeyUri", () => {
+    const secretKey = Secret.from(secret, "ascii");
+    const hotp = new HOTP({ secret: secretKey, account: "user@example.com" });
+    expect(hotp.keyUri()).toBe(hotp.toKeyUri());
+  });
+});

--- a/tests/secret.test.ts
+++ b/tests/secret.test.ts
@@ -1,0 +1,46 @@
+import { Secret } from "../src";
+import type { Algorithm } from "../src/types";
+
+const recommendedSizes: [Algorithm, number][] = [
+  ["sha1", 160 / 8],
+  ["sha224", 224 / 8],
+  ["sha-512/224", 224 / 8],
+  ["sha3-224", 224 / 8],
+  ["sha256", 256 / 8],
+  ["sha-512/256", 256 / 8],
+  ["sha3-256", 256 / 8],
+  ["sha384", 384 / 8],
+  ["sha3-384", 384 / 8],
+  ["sha512", 512 / 8],
+  ["sha3-512", 512 / 8],
+];
+
+describe("Secret", () => {
+  test("throws when constructor args cannot produce a buffer", () => {
+    expect(() => new Secret({ size: 0 })).toThrow(
+      /Constructor arguments are not valid/,
+    );
+  });
+
+  test("from(Buffer) wraps the buffer", () => {
+    const buf = Buffer.from("hello");
+    expect(Secret.from(buf).buffer).toEqual(buf);
+  });
+
+  test("toString with non-base32 encoding", () => {
+    const secret = Secret.from("hello", "ascii");
+    expect(secret.toString("ascii")).toBe("hello");
+    expect(secret.toString("hex")).toBe("68656c6c6f");
+  });
+
+  test.each(recommendedSizes)(
+    "for(%s) creates a secret of recommended byte length",
+    (algorithm, expectedLength) => {
+      expect(Secret.for(algorithm).buffer.length).toBe(expectedLength);
+    },
+  );
+
+  test("custom size creates a secret of given length", () => {
+    expect(new Secret({ size: 32 }).buffer.length).toBe(32);
+  });
+});

--- a/tests/totp.test.ts
+++ b/tests/totp.test.ts
@@ -98,3 +98,22 @@ describe("instance secret", () => {
     expect(totp.validate({ token, timestamp: timestamp * 1000 })).toBe(true);
   });
 });
+
+describe("timeUsed and timeRemaining", () => {
+  test("reports elapsed and remaining seconds in the current step", () => {
+    const totp = new TOTP({ duration: 30 });
+    expect(totp.timeUsed({ timestamp: 59_000 })).toBe(29);
+    expect(totp.timeRemaining({ timestamp: 59_000 })).toBe(1);
+  });
+});
+
+describe("equals", () => {
+  test("matches generate output for the same timestamp", () => {
+    const secretKey = Secret.from(secret.sha1, "ascii");
+    const totp = new TOTP({ secret: secretKey, digits: 8, duration });
+    const timestamp = data[0].timestamp * 1000;
+    const token = totp.generate({ timestamp });
+    expect(totp.equals({ token, timestamp })).toBe(true);
+    expect(totp.equals({ token: "00000000", timestamp })).toBe(false);
+  });
+});

--- a/tests/uri.test.ts
+++ b/tests/uri.test.ts
@@ -78,6 +78,14 @@ describe("URI.parse", () => {
       ),
     ).toThrow(/must be equal/);
   });
+
+  test("throws on invalid period", () => {
+    expect(() =>
+      URI.parse(
+        "otpauth://totp/user?secret=JBSWY3DPEHPK3PXP&period=0",
+      ),
+    ).toThrow(/Invalid period/);
+  });
 });
 
 describe("URI.format", () => {


### PR DESCRIPTION
## Summary
- Add tests for previously uncovered paths in `Secret`, `uint8`, TOTP (`timeUsed`, `timeRemaining`, `equals`), HOTP (`validate`, negative-window `compare`, deprecated `keyUri`), and URI parsing (`period=0`).
- Restore Jest coverage config (`src/**/*.ts`, lcov output) and fix the `test:coverage` script.
- Run coverage in CI and upload to CodeCov so the badge reflects current results.
Coverage after this change: ~**99.7%** lines, ~**87%** branches, **100%** functions (114 tests).

## Test plan
- [x] `npm test`
- [x] `npm run test:coverage`
- [x] `npm run build`
- [ ] Confirm CodeCov upload succeeds on CI (requires `CODECOV_TOKEN`)